### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,27 +16,37 @@ then either add it to an existing bunyan logger or pass an instance to a new
 bunyan logger:
 
 ``` js
-var GoodBunyan = require('gooder-bunyan');
 var bunyan = require('bunyan');
+var hapi = require('hapi');
+
+var server = new hapi.Server();
+server.connection({ port: 8000 });
+
+var logger = bunyan.createLogger({ name: 'test', level: 'debug' });
 
 server.register({
   register: require('good'),
   options: {
-    reporters: [
-      new GoodBunyan({
-        ops: '*',
-        request: '*',
-        response: '*',
-        log: '*',
-        error: '*'
-      }, bunyan)
-    ]
+    reporters: {
+      bunyanReporter: [{
+        module: 'gooder-bunyan',
+        args: [logger, {
+          ops: '*',
+          request: '*',
+          response: '*',
+          log: '*',
+          error: '*',
+        }]
+      }]
+    }
   }
 }, function(err) {
   if (err) {
     return server.log(['error'], 'good load error: ' + err);
   }
 });
+
+server.start();
 ```
 
 The following `options` are availble to configure `GoodBunyan`:


### PR DESCRIPTION
The existing example doesn't appear to work with good 7.x.x as used in the dependencies. Updated to the new format.

Using Bunyan directly caused a bind error, so create a logger to pass in.

Include rest of Hapi setup so it's a complete example.